### PR TITLE
fix: use other svc types

### DIFF
--- a/guestbook/values-dev.yaml
+++ b/guestbook/values-dev.yaml
@@ -1,2 +1,2 @@
 service:
-  type: LoadBalancer
+  type: ClusterIP

--- a/guestbook/values-prd.yaml
+++ b/guestbook/values-prd.yaml
@@ -1,2 +1,2 @@
 service:
-  type: LoadBalancer
+  type: NodePort

--- a/guestbook/values-stg.yaml
+++ b/guestbook/values-stg.yaml
@@ -1,2 +1,2 @@
 service:
-  type: LoadBalancer
+  type: NodePort


### PR DESCRIPTION
k3d (or kind) doesn't have load balancer controllers to assign IPs to services of type LoadBalancer so the apps remain in a progressing state. This fixes that, closes #13 